### PR TITLE
Fix bug in dataset.preprocessText()

### DIFF
--- a/keras_wrapper/dataset.py
+++ b/keras_wrapper/dataset.py
@@ -1683,14 +1683,7 @@ class Dataset(object):
             tokfun = None
 
         # Build vocabulary
-        if build_vocabulary:
-            self.build_vocabulary(sentences, data_id,
-                                  max_text_len != 0,
-                                  min_occ=min_occ,
-                                  n_words=max_words,
-                                  use_extra_words=(max_text_len != 0),
-                                  use_unk_class=use_unk_class)
-        elif isinstance(build_vocabulary, str):
+        if isinstance(build_vocabulary, str):
             if build_vocabulary in self.vocabulary:
                 self.vocabulary[data_id] = self.vocabulary[build_vocabulary]
                 self.vocabulary_len[data_id] = self.vocabulary_len[build_vocabulary]
@@ -1705,6 +1698,14 @@ class Dataset(object):
             self.vocabulary[data_id] = build_vocabulary
             if not self.silence:
                 logger.info('\tReusing vocabulary from dictionary for data with data_id "' + data_id + '".')
+
+        elif build_vocabulary:
+            self.build_vocabulary(sentences, data_id,
+                                  max_text_len != 0,
+                                  min_occ=min_occ,
+                                  n_words=max_words,
+                                  use_extra_words=(max_text_len != 0),
+                                  use_unk_class=use_unk_class)
 
         if data_id not in self.vocabulary:
             raise Exception('The dataset must include a vocabulary with data_id "' + data_id +


### PR DESCRIPTION
We noticed what appears to be a bug in `multimodal_keras_wrapper.dataset.preprocessText()` line 1686 (https://github.com/lvapeab/multimodal_keras_wrapper/blob/master/keras_wrapper/dataset.py) relating to the build_vocabulary variable, which can be taken as a boolean, string or dictionary.

As it is:
```python
# Build vocabulary
        if build_vocabulary:
            self.build_vocabulary(sentences, data_id,
                                  max_text_len != 0,
                                  min_occ=min_occ,
                                  n_words=max_words,
                                  use_extra_words=(max_text_len != 0),
                                  use_unk_class=use_unk_class)
        elif isinstance(build_vocabulary, str):
            if build_vocabulary in self.vocabulary:
                self.vocabulary[data_id] = self.vocabulary[build_vocabulary]
                self.vocabulary_len[data_id] = self.vocabulary_len[build_vocabulary]
                if not self.silence:
                    logger.info('\tReusing vocabulary named "' + build_vocabulary + '" for data with data_id "' + data_id + '".')
            else:
                raise Exception('The parameter "build_vocabulary" must be a boolean '
                                'or a str containing an data_id of the vocabulary we want to copy.\n'
                                'It currently is: %s' % str(build_vocabulary))

        elif isinstance(build_vocabulary, dict):
            self.vocabulary[data_id] = build_vocabulary
            if not self.silence:
                logger.info('\tReusing vocabulary from dictionary for data with data_id "' + data_id + '".')
```

executes the first block of the `if` statement if `build_vocabulary` has any value other than empty or `False` and therefore if it is a non-empty string or dictionary, the second and third blocks are not executed.

we propose changing this to:
```python
if isinstance(build_vocabulary, str):
        if build_vocabulary in self.vocabulary:
                self.vocabulary[data_id] = self.vocabulary[build_vocabulary]
                self.vocabulary_len[data_id] = self.vocabulary_len[build_vocabulary]
            if not self.silence:
                    logger.info('\tReusing vocabulary named "' + build_vocabulary + '" for data with data_id "' + data_id + '".')
            else:
                raise Exception('The parameter "build_vocabulary" must be a boolean '
                                'or a str containing an data_id of the vocabulary we want to copy.\n'
                                'It currently is: %s' % str(build_vocabulary))

        elif isinstance(build_vocabulary, dict):
            self.vocabulary[data_id] = build_vocabulary
            if not self.silence:
                logger.info('\tReusing vocabulary from dictionary for data with data_id "' + data_id + '".')
        
        elif build_vocabulary:
            self.build_vocabulary(sentences, data_id,
                                  max_text_len != 0,
                                  min_occ=min_occ,
                                  n_words=max_words,
                                  use_extra_words=(max_text_len != 0),
                                  use_unk_class=use_unk_class)
```

In which a new vocabulary is only built if `build_vocabulary` is not a string or dictionary and is `True`.